### PR TITLE
ビルド環境セットアップスクリプトの追加と設定整備

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,4 +1,43 @@
+[alias]
+x = "run --package xtask --"
+
+# =============================================================================
+# Windows Build Configuration
+# =============================================================================
+# Native dependencies:
+# - FFmpeg: Manually installed by user (set FFMPEG_DIR to your install path)
+# - OpenCV: Official Windows release installed by `cargo x setup`
+# - LLVM:   Required for opencv-rs bindgen, installed by `cargo x setup`
+#
+# Run `cargo x setup` to install OpenCV and LLVM automatically.
+# FFmpeg must be installed manually - see README for instructions.
+# =============================================================================
+
+[target.x86_64-pc-windows-msvc]
+linker = "link.exe"
+
+rustflags = [
+    "-L", "D:\\libs\\vcpkg\\installed\\x64-windows\\lib",
+    "-L", "D:\\libs\\opencv\\build\\x64\\vc16\\lib",
+]
+
 [env]
-OPENSSL_DIR = "/usr"
-OPENSSL_LIB_DIR = "/usr/lib/x86_64-linux-gnu"
-OPENSSL_INCLUDE_DIR = "/usr/include"
+# FFmpeg: MSVC build via vcpkg at D:\libs\vcpkg (required for MSVC Rust toolchain)
+FFMPEG_DIR = { value = "D:\\libs\\vcpkg\\installed\\x64-windows", force = true }
+
+# LLVM/Clang: required for opencv-rs bindgen
+LIBCLANG_PATH = { value = "C:\\Program Files\\LLVM\\bin", force = true }
+
+# OpenCV: installed by `cargo x setup`
+# OPENCV_DIR is used by the opencv-rs build script
+OPENCV_DIR = { value = "D:\\libs\\opencv\\build", force = true }
+# OpenCV_DIR (mixed case) is used by cmake's find_package(OpenCV)
+OpenCV_DIR = { value = "D:\\libs\\opencv\\build", force = true }
+OPENCV_INCLUDE_PATHS = { value = "D:\\libs\\opencv\\build\\include", force = true }
+OPENCV_LINK_PATHS = { value = "D:\\libs\\opencv\\build\\x64\\vc16\\lib", force = true }
+OPENCV_LINK_LIBS = { value = "opencv_world490", force = true }
+
+# Linux/macOS OpenSSL
+OPENSSL_DIR = { value = "/usr", force = false }
+OPENSSL_LIB_DIR = { value = "/usr/lib/x86_64-linux-gnu", force = false }
+OPENSSL_INCLUDE_DIR = { value = "/usr/include", force = false }

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,18 +1,21 @@
-## Description
+## Summary
 
-Please describe what this PR does.
+<!-- What this PR does and why, in 1–4 sentences. -->
 
-## Related Issue
+## Changes
 
-Closes #
+<!-- List of notable changes. For bug fixes, include root cause and fix.
+     For new features, include what was added. For tests, list what was covered. -->
 
-## Checklist
+## Related Issues
 
-- [ ] Code compiles correctly
-- [ ] Tests have been added or updated
-- [ ] Documentation has been updated (if needed)
-- [ ] I have run `cargo fmt` and `cargo clippy`
+<!-- Use the keyword that fits:
+     Closes #N  — feature implementation or task completion
+     Fixes #N   — bug fix
+     Resolves #N — general resolution (discussion, refactor, etc.) -->
 
-## Screenshots (if applicable)
+## Test Plan
 
-Attach screenshots or terminal output here.
+- [ ] `cargo test --all --all-features` passes
+- [ ] `cargo clippy --all --all-features -- -D warnings` passes
+- [ ] `cargo fmt --all -- --check` passes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,8 @@
 members = [
     "media-core",
     "terminal-player",
-    "downloader"
+    "downloader",
+    "xtask"
 ]
 
 resolver = "3"

--- a/media-core/Cargo.toml
+++ b/media-core/Cargo.toml
@@ -36,5 +36,3 @@ tempfile = { workspace = true }
 # 数値計算
 num = { workspace = true }
 
-[build-dependencies]
-pkg-config = "0.3.32"

--- a/media-core/build.rs
+++ b/media-core/build.rs
@@ -33,11 +33,11 @@ fn configure_windows() {
     println!("cargo:rustc-link-lib=user32");
     println!("cargo:rustc-link-lib=kernel32");
 
-    // Windows での vcpkg 使用を推奨
-    if let Ok(vcpkg_root) = env::var("VCPKG_ROOT") {
+    // FFmpeg: manually installed, pointed to by FFMPEG_DIR
+    if let Ok(ffmpeg_dir) = env::var("FFMPEG_DIR") {
         println!(
-            "cargo:rustc-link-search=native={}\\installed\\x64-windows\\lib",
-            vcpkg_root
+            "cargo:rustc-link-search=native={}\\lib",
+            ffmpeg_dir
         );
     }
 }
@@ -66,47 +66,18 @@ fn configure_linux() {
 }
 
 fn configure_opencv() {
-    // OpenCV 環境変数チェック
+    // OpenCV 環境変数チェック (OPENCV_DIR は cargo x setup で設定される)
     if let Ok(opencv_dir) = env::var("OPENCV_DIR") {
         println!("cargo:rustc-link-search=native={}/lib", opencv_dir);
-    }
-
-    // pkg-config を使用して OpenCV を検出
-    if pkg_config::probe_library("opencv4")
-        .or_else(|_| pkg_config::probe_library("opencv"))
-        .is_err()
-    {
-        println!("cargo:warning=OpenCV not found via pkg-config, using system defaults");
+        println!("cargo:rustc-link-search=native={}/x64/vc16/lib", opencv_dir);
     }
 }
 
 fn configure_ffmpeg() {
-    // FFmpeg 環境変数チェック
+    // FFmpeg 環境変数チェック (FFMPEG_DIR はユーザーが手動でインストールして設定する)
     if let Ok(ffmpeg_dir) = env::var("FFMPEG_DIR") {
         println!("cargo:rustc-link-search=native={}/lib", ffmpeg_dir);
-    }
-
-    // pkg-config を使用して FFmpeg を検出
-    let ffmpeg_libs = [
-        "libavformat",
-        "libavcodec",
-        "libavutil",
-        "libswscale",
-        "libswresample",
-    ];
-
-    for lib in &ffmpeg_libs {
-        if pkg_config::probe_library(lib).is_err() {
-            println!("cargo:warning={} not found via pkg-config", lib);
-        }
-    }
-
-    // 静的リンクが有効な場合の設定
-    if env::var("CARGO_FEATURE_FFMPEG_STATIC").is_ok() {
-        println!("cargo:rustc-link-lib=static=avformat");
-        println!("cargo:rustc-link-lib=static=avcodec");
-        println!("cargo:rustc-link-lib=static=avutil");
-        println!("cargo:rustc-link-lib=static=swscale");
-        println!("cargo:rustc-link-lib=static=swresample");
+    } else {
+        println!("cargo:warning=FFMPEG_DIR is not set. Please install FFmpeg and set FFMPEG_DIR.");
     }
 }

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -1,0 +1,211 @@
+#!/bin/bash
+# ascii-term - System Dependencies Installation Script
+#
+# This script installs all required system libraries for building ascii-term.
+# Supports: Ubuntu/Debian, Fedora, Arch Linux, macOS (Homebrew)
+# Windows: use `cargo x setup` instead.
+
+set -e  # Exit on error
+
+# Color codes for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+print_info()    { echo -e "${BLUE}[INFO]${NC} $1"; }
+print_success() { echo -e "${GREEN}[SUCCESS]${NC} $1"; }
+print_warning() { echo -e "${YELLOW}[WARNING]${NC} $1"; }
+print_error()   { echo -e "${RED}[ERROR]${NC} $1"; }
+
+# Detect operating system
+detect_os() {
+    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        if [ -f /etc/debian_version ]; then
+            echo "debian"
+        elif [ -f /etc/fedora-release ]; then
+            echo "fedora"
+        elif [ -f /etc/arch-release ]; then
+            echo "arch"
+        else
+            echo "linux-unknown"
+        fi
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        echo "macos"
+    else
+        echo "unknown"
+    fi
+}
+
+install_debian() {
+    print_info "Installing dependencies for Ubuntu/Debian..."
+
+    sudo apt-get update
+
+    print_info "Installing FFmpeg development libraries..."
+    sudo apt-get install -y \
+        libavcodec-dev \
+        libavformat-dev \
+        libavutil-dev \
+        libavdevice-dev \
+        libavfilter-dev \
+        libswscale-dev \
+        libswresample-dev
+
+    print_info "Installing OpenCV..."
+    sudo apt-get install -y libopencv-dev
+
+    print_info "Installing build tools..."
+    sudo apt-get install -y \
+        pkg-config \
+        clang \
+        libclang-dev \
+        cmake
+
+    print_info "Installing audio libraries..."
+    sudo apt-get install -y libasound2-dev
+
+    print_success "All dependencies installed successfully!"
+}
+
+install_fedora() {
+    print_info "Installing dependencies for Fedora..."
+
+    print_info "Installing FFmpeg development libraries..."
+    sudo dnf install -y ffmpeg-devel
+
+    print_info "Installing OpenCV..."
+    sudo dnf install -y opencv-devel
+
+    print_info "Installing build tools..."
+    sudo dnf install -y \
+        pkg-config \
+        clang \
+        clang-devel \
+        cmake
+
+    print_info "Installing audio libraries..."
+    sudo dnf install -y alsa-lib-devel
+
+    print_success "All dependencies installed successfully!"
+}
+
+install_arch() {
+    print_info "Installing dependencies for Arch Linux..."
+
+    sudo pacman -Sy
+    sudo pacman -S --needed --noconfirm \
+        ffmpeg \
+        opencv \
+        alsa-lib \
+        pkg-config \
+        clang \
+        cmake
+
+    print_success "All dependencies installed successfully!"
+}
+
+install_macos() {
+    print_info "Installing dependencies for macOS..."
+
+    if ! command -v brew &> /dev/null; then
+        print_error "Homebrew is not installed. Please install it first:"
+        print_info "Visit: https://brew.sh/"
+        exit 1
+    fi
+
+    brew update
+
+    print_info "Installing FFmpeg..."
+    brew install ffmpeg
+
+    print_info "Installing OpenCV..."
+    brew install opencv
+
+    print_info "Installing build tools..."
+    brew install pkg-config cmake llvm
+
+    # brew's LLVM is not in PATH by default; opencv-rs bindgen needs LIBCLANG_PATH
+    LLVM_PREFIX=$(brew --prefix llvm 2>/dev/null)
+    if [ -n "$LLVM_PREFIX" ]; then
+        print_info "Setting LIBCLANG_PATH for current session..."
+        export LIBCLANG_PATH="${LLVM_PREFIX}/lib"
+        print_success "LIBCLANG_PATH=${LIBCLANG_PATH}"
+        print_warning "Add to your shell profile (~/.zshrc or ~/.bash_profile):"
+        print_info "  export LIBCLANG_PATH=${LLVM_PREFIX}/lib"
+    fi
+
+    if ! xcode-select -p &> /dev/null; then
+        print_warning "Xcode Command Line Tools not found. Installing..."
+        xcode-select --install
+    fi
+
+    print_success "All dependencies installed successfully!"
+}
+
+verify_installation() {
+    print_info "Verifying installation..."
+
+    local has_error=0
+
+    if command -v pkg-config &> /dev/null; then
+        print_success "pkg-config found"
+
+        if pkg-config --exists libavcodec; then
+            print_success "FFmpeg found (version: $(pkg-config --modversion libavcodec))"
+        else
+            print_error "FFmpeg libraries not found via pkg-config"
+            has_error=1
+        fi
+
+        if pkg-config --exists opencv4 || pkg-config --exists opencv; then
+            print_success "OpenCV found"
+        else
+            print_warning "OpenCV not found (optional)"
+        fi
+    else
+        print_error "pkg-config not found"
+        has_error=1
+    fi
+
+    return $has_error
+}
+
+main() {
+    echo ""
+    print_info "ascii-term - Dependency Installation Script"
+    echo "============================================="
+    echo ""
+
+    OS=$(detect_os)
+    print_info "Detected OS: $OS"
+    echo ""
+
+    case $OS in
+        debian)   install_debian ;;
+        fedora)   install_fedora ;;
+        arch)     install_arch ;;
+        macos)    install_macos ;;
+        *)
+            print_error "Unsupported OS: $OS"
+            print_info "On Windows, use: cargo x setup"
+            exit 1
+            ;;
+    esac
+
+    echo ""
+
+    if verify_installation; then
+        echo ""
+        print_success "Installation completed successfully!"
+        print_info "You can now build ascii-term: cargo build"
+    else
+        echo ""
+        print_warning "Installation completed with some warnings."
+        print_info "Please check the errors above and install missing dependencies manually."
+        exit 1
+    fi
+}
+
+main

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "xtask"
+version = "0.1.0"
+edition = "2024"
+publish = false
+description = "Development automation tool for ascii-term - CI, testing, setup"
+
+[dependencies]
+clap = { version = "4.5.60", features = ["derive"] }
+anyhow = "1.0.102"
+colored = "3.1.1"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,0 +1,278 @@
+mod setup;
+
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+use colored::*;
+use std::process::{Command, Stdio};
+use std::time::Instant;
+
+#[derive(Parser)]
+#[command(name = "x")]
+#[command(about = "Development automation for ascii-term")]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Run all CI checks (fmt, clippy, build, test)
+    Ci {
+        #[arg(long)]
+        verbose: bool,
+    },
+    /// Run tests (unit tests only by default, use --all for everything)
+    Test {
+        #[arg(long)]
+        doc: bool,
+        #[arg(long)]
+        ignored: bool,
+        /// Run tests for specific package (media-core, terminal-player, downloader)
+        #[arg(short = 'p', long)]
+        package: Option<String>,
+        /// Run tests sequentially (saves memory)
+        #[arg(long)]
+        sequential: bool,
+        /// Include integration tests (tests/ folder)
+        #[arg(long)]
+        integration: bool,
+        /// Run all tests including integration tests
+        #[arg(long)]
+        all: bool,
+    },
+    /// Pre-commit hook (fmt, clippy, test)
+    PreCommit,
+    /// Install git hooks
+    InstallHooks,
+    /// Setup development environment (auto-detects platform)
+    Setup {
+        /// Skip verification step
+        #[arg(long)]
+        skip_verify: bool,
+    },
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+
+    match cli.command {
+        Commands::Ci { verbose } => run_ci(verbose),
+        Commands::Test {
+            doc,
+            ignored,
+            package,
+            sequential,
+            integration,
+            all,
+        } => run_test(doc, ignored, package.as_deref(), sequential, integration, all),
+        Commands::PreCommit => run_pre_commit(),
+        Commands::InstallHooks => install_hooks(),
+        Commands::Setup { skip_verify } => setup::run_setup(skip_verify),
+    }
+}
+
+fn run_ci(verbose: bool) -> Result<()> {
+    println!("{}", "=== Running CI Pipeline ===".bold().blue());
+
+    let start = Instant::now();
+
+    run_task("Format Check", || run_fmt(true), verbose)?;
+    run_task("Clippy", || run_clippy(false), verbose)?;
+    run_task("Build", || run_build(false, None), verbose)?;
+    run_task(
+        "Test",
+        || run_test(false, false, None, false, false, true),
+        verbose,
+    )?;
+
+    let elapsed = start.elapsed();
+    println!(
+        "\n{} {}",
+        "✓ CI passed in".green().bold(),
+        format!("{:.2}s", elapsed.as_secs_f64()).bold()
+    );
+
+    Ok(())
+}
+
+fn run_fmt(check: bool) -> Result<()> {
+    let mut cmd = Command::new("cargo");
+    cmd.arg("fmt").arg("--all");
+
+    if check {
+        cmd.arg("--").arg("--check");
+    }
+
+    execute_command(&mut cmd)
+}
+
+fn run_clippy(fix: bool) -> Result<()> {
+    let mut cmd = Command::new("cargo");
+    cmd.arg("clippy").arg("--all-targets").arg("--all-features");
+
+    if fix {
+        cmd.arg("--fix");
+    } else {
+        cmd.arg("--").arg("-D").arg("warnings");
+    }
+
+    execute_command(&mut cmd)
+}
+
+fn run_build(release: bool, package: Option<&str>) -> Result<()> {
+    let mut cmd = Command::new("cargo");
+    cmd.arg("build");
+
+    if release {
+        cmd.arg("--release");
+    }
+
+    if let Some(pkg) = package {
+        cmd.arg("--package").arg(pkg);
+    } else {
+        cmd.arg("--workspace");
+    }
+
+    execute_command(&mut cmd)
+}
+
+fn run_test(
+    doc: bool,
+    ignored: bool,
+    package: Option<&str>,
+    sequential: bool,
+    integration: bool,
+    all: bool,
+) -> Result<()> {
+    if doc {
+        let mut cmd = Command::new("cargo");
+        cmd.arg("test").arg("--workspace").arg("--doc");
+
+        if ignored {
+            cmd.arg("--").arg("--ignored");
+        }
+
+        return execute_command(&mut cmd);
+    }
+
+    let mut cmd = Command::new("cargo");
+    cmd.arg("test");
+
+    if let Some(pkg) = package {
+        cmd.arg("--package").arg(pkg);
+    } else {
+        cmd.arg("--workspace");
+    }
+
+    if all {
+        cmd.arg("--lib").arg("--tests");
+    } else if integration {
+        cmd.arg("--tests");
+    } else {
+        cmd.arg("--lib");
+    }
+
+    if sequential {
+        cmd.arg("--").arg("--test-threads=1");
+    } else if ignored {
+        cmd.arg("--").arg("--ignored");
+    }
+
+    execute_command(&mut cmd)
+}
+
+fn run_pre_commit() -> Result<()> {
+    println!("{}", "=== Pre-commit Checks ===".bold().blue());
+
+    let start = Instant::now();
+
+    run_task("Format Check", || run_fmt(true), false)?;
+    run_task("Clippy", || run_clippy(false), false)?;
+    run_task(
+        "Test",
+        || run_test(false, false, None, false, false, false),
+        false,
+    )?;
+
+    let elapsed = start.elapsed();
+    println!(
+        "\n{} {}",
+        "✓ Pre-commit checks passed in".green().bold(),
+        format!("{:.2}s", elapsed.as_secs_f64()).bold()
+    );
+
+    Ok(())
+}
+
+fn install_hooks() -> Result<()> {
+    use std::fs;
+
+    println!("{}", "Installing git hooks...".bold());
+
+    let hook_content = r#"#!/bin/sh
+# Auto-generated by cargo x install-hooks
+set -e
+
+echo "Running pre-commit checks..."
+cargo x pre-commit
+"#;
+
+    let hook_path = ".git/hooks/pre-commit";
+    fs::write(hook_path, hook_content)?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let mut perms = fs::metadata(hook_path)?.permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(hook_path, perms)?;
+    }
+
+    println!("{}", "✓ Git hooks installed".green());
+    println!("  Pre-commit hook will run: fmt, clippy, test");
+
+    Ok(())
+}
+
+fn run_task<F>(name: &str, task: F, verbose: bool) -> Result<()>
+where
+    F: FnOnce() -> Result<()>,
+{
+    print!("{} {} ... ", "→".blue(), name);
+
+    let start = Instant::now();
+
+    match task() {
+        Ok(_) => {
+            let elapsed = start.elapsed();
+            println!(
+                "{} {}",
+                "✓".green().bold(),
+                if verbose {
+                    format!("({:.2}s)", elapsed.as_secs_f64())
+                } else {
+                    String::new()
+                }
+            );
+            Ok(())
+        }
+        Err(e) => {
+            println!("{}", "✗".red().bold());
+            Err(e)
+        }
+    }
+}
+
+pub fn execute_command(cmd: &mut Command) -> Result<()> {
+    let status = cmd
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .status()?;
+
+    if !status.success() {
+        anyhow::bail!("Command failed with exit code: {}", status);
+    }
+
+    Ok(())
+}

--- a/xtask/src/setup.rs
+++ b/xtask/src/setup.rs
@@ -1,0 +1,737 @@
+//! Development environment setup commands
+//!
+//! Platform-specific setup for FFmpeg, OpenCV, and build tools.
+//!
+//! # Dependency Strategy
+//!
+//! - FFmpeg: Manually installed by the user (set FFMPEG_DIR env var)
+//! - OpenCV: Installed via official Windows release or system package manager
+//! - LLVM/Clang: Required for opencv-rs bindgen
+
+use anyhow::Result;
+use colored::*;
+use std::process::{Command, Stdio};
+
+#[allow(unused_imports)]
+use crate::execute_command;
+
+/// Run setup for the current platform
+pub fn run_setup(skip_verify: bool) -> Result<()> {
+    println!(
+        "{}",
+        "=== ascii-term Development Environment Setup ==="
+            .bold()
+            .blue()
+    );
+    println!();
+
+    let os = std::env::consts::OS;
+    println!("{} Detected platform: {}", "→".blue(), os.bold());
+    println!();
+
+    match os {
+        "windows" => setup_windows(skip_verify),
+        "linux" => setup_linux(skip_verify),
+        "macos" => setup_macos(skip_verify),
+        _ => {
+            println!("{} Unsupported platform: {}", "✗".red().bold(), os);
+            anyhow::bail!("Unsupported platform")
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn setup_windows(skip_verify: bool) -> Result<()> {
+    use std::path::Path;
+
+    println!("{}", "Checking prerequisites...".bold());
+    check_command("git", "Git not found. Install from: https://git-scm.com/")?;
+    check_command("cargo", "Rust not found. Install from: https://rustup.rs/")?;
+
+    let has_choco = Command::new("choco")
+        .arg("--version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+
+    if has_choco {
+        println!("{} Chocolatey found", "✓".green());
+    } else {
+        println!(
+            "{} Chocolatey not found (optional but recommended)",
+            "⚠".yellow()
+        );
+        println!(
+            "   {} Install from: {}",
+            "→".blue(),
+            "https://chocolatey.org/".cyan()
+        );
+    }
+
+    if !is_admin()? {
+        println!();
+        println!("{}", "✗ Administrator privileges required".red().bold());
+        println!();
+        println!(
+            "{} Please run this command in an elevated terminal:",
+            "→".blue()
+        );
+        println!(
+            "   {}",
+            "1. Right-click on your terminal (PowerShell/Git Bash)".cyan()
+        );
+        println!("   {}", "2. Select 'Run as Administrator'".cyan());
+        println!(
+            "   {}",
+            "3. Navigate to this directory and run: cargo x setup".cyan()
+        );
+        println!();
+        anyhow::bail!("Administrator privileges required");
+    }
+
+    println!("{} Prerequisites OK", "✓".green());
+    println!();
+
+    // Build tools (cmake, pkg-config)
+    println!("{}", "Setting up build tools...".bold());
+    setup_build_tools()?;
+    println!();
+
+    // FFmpeg: install pre-built binaries directly to D:\libs\ffmpeg
+    println!("{}", "Setting up FFmpeg...".bold());
+    setup_ffmpeg_windows()?;
+    println!();
+
+    // OpenCV: install directly
+    println!("{}", "Setting up OpenCV...".bold());
+    let opencv_dir = Path::new("D:\\libs\\opencv");
+    if !opencv_dir.join("build").exists() {
+        println!("{} OpenCV not found, installing...", "→".blue());
+
+        run_powershell("if (!(Test-Path D:\\libs)) { New-Item -ItemType Directory -Path D:\\libs }")?;
+        run_powershell("if (!(Test-Path D:\\libs\\tmp)) { New-Item -ItemType Directory -Path D:\\libs\\tmp }")?;
+
+        println!(
+            "{} Downloading OpenCV (this may take a while)...",
+            "→".blue()
+        );
+        run_powershell(
+            "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; Invoke-WebRequest -Uri 'https://github.com/opencv/opencv/releases/download/4.9.0/opencv-4.9.0-windows.exe' -OutFile 'D:\\libs\\tmp\\opencv.exe' -UseBasicParsing",
+        )?;
+
+        println!("{} Extracting OpenCV...", "→".blue());
+        run_powershell(
+            "Start-Process -FilePath D:\\libs\\tmp\\opencv.exe -ArgumentList '-oD:\\libs -y' -Wait",
+        )?;
+
+        println!("{} Cleaning up temporary files...", "→".blue());
+        let _ = run_powershell(
+            "Remove-Item -Path 'D:\\libs\\tmp\\opencv.exe' -Force -ErrorAction SilentlyContinue",
+        );
+
+        println!("{} OpenCV installed to D:\\libs\\opencv", "✓".green());
+    } else {
+        println!("{} OpenCV already installed", "✓".green());
+    }
+
+    println!("{} Setting OpenCV environment variables...", "→".blue());
+    run_powershell(
+        "[Environment]::SetEnvironmentVariable('OPENCV_DIR', 'D:\\libs\\opencv\\build', 'User')",
+    )?;
+    run_powershell(
+        "[Environment]::SetEnvironmentVariable('OPENCV_INCLUDE_PATHS', 'D:\\libs\\opencv\\build\\include', 'User')",
+    )?;
+    run_powershell(
+        "[Environment]::SetEnvironmentVariable('OPENCV_LINK_PATHS', 'D:\\libs\\opencv\\build\\x64\\vc16\\lib', 'User')",
+    )?;
+    run_powershell(
+        "[Environment]::SetEnvironmentVariable('OPENCV_LINK_LIBS', 'opencv_world490', 'User')",
+    )?;
+    run_powershell(
+        "$path = [Environment]::GetEnvironmentVariable('Path', 'User'); if ($path -notlike '*D:\\libs\\opencv\\build\\x64\\vc16\\bin*') { [Environment]::SetEnvironmentVariable('Path', $path + ';D:\\libs\\opencv\\build\\x64\\vc16\\bin', 'User') }",
+    )?;
+    println!("{} Environment variables set", "✓".green());
+    println!();
+
+    // LLVM: required for opencv-rs clang-runtime feature
+    println!("{}", "Setting up LLVM (clang)...".bold());
+    let llvm_installed = Command::new("clang")
+        .arg("--version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+
+    if !llvm_installed {
+        let llvm_path = Path::new("C:\\Program Files\\LLVM\\bin\\clang.exe");
+        if !llvm_path.exists() {
+            println!(
+                "{} LLVM/clang not found, installing via Chocolatey...",
+                "→".blue()
+            );
+
+            let mut cmd = Command::new("choco");
+            cmd.arg("install").arg("llvm").arg("-y");
+
+            let status = cmd
+                .stdout(Stdio::inherit())
+                .stderr(Stdio::inherit())
+                .status();
+
+            match status {
+                Ok(s) if s.success() => {
+                    println!("{} LLVM installed", "✓".green());
+                }
+                _ => {
+                    println!("{} LLVM installation failed", "✗".red().bold());
+                    println!(
+                        "{} Please install LLVM manually from: {}",
+                        "→".blue(),
+                        "https://releases.llvm.org/".cyan()
+                    );
+                    anyhow::bail!("Failed to install LLVM");
+                }
+            }
+        } else {
+            println!("{} LLVM already installed (not in PATH)", "✓".green());
+            println!("{} Adding LLVM to PATH...", "→".blue());
+            run_powershell(
+                "$path = [Environment]::GetEnvironmentVariable('Path', 'User'); if ($path -notlike '*C:\\Program Files\\LLVM\\bin*') { [Environment]::SetEnvironmentVariable('Path', $path + ';C:\\Program Files\\LLVM\\bin', 'User') }",
+            )?;
+        }
+    } else {
+        println!("{} LLVM/clang already installed", "✓".green());
+    }
+    println!();
+
+    if !skip_verify {
+        println!("{}", "Verifying installation...".bold());
+        verify_windows_setup()?;
+    }
+
+    println!();
+    println!("{}", "✅ Setup complete!".green().bold());
+    println!();
+    println!(
+        "{} Please restart your terminal to apply environment variable changes",
+        "ℹ".blue()
+    );
+    println!("{} Then run: {}", "→".blue(), "cargo build".cyan());
+
+    Ok(())
+}
+
+#[cfg(not(target_os = "windows"))]
+fn setup_windows(_skip_verify: bool) -> Result<()> {
+    anyhow::bail!("Windows setup can only be run on Windows")
+}
+
+#[cfg(target_os = "windows")]
+fn setup_ffmpeg_windows() -> Result<()> {
+    use std::path::Path;
+
+    // FFmpeg via vcpkg (MSVC build) - required for compatibility with the MSVC Rust toolchain
+    let vcpkg_dir = Path::new("D:\\libs\\vcpkg");
+    let vcpkg_exe = vcpkg_dir.join("vcpkg.exe");
+    let ffmpeg_lib = Path::new("D:\\libs\\vcpkg\\installed\\x64-windows\\lib\\avcodec.lib");
+
+    // Step 1: Install or update vcpkg
+    if vcpkg_exe.exists() {
+        println!("{} vcpkg already installed at D:\\libs\\vcpkg", "✓".green());
+        println!("{} Updating vcpkg...", "→".blue());
+        let _ = Command::new("git")
+            .args(["pull"])
+            .current_dir(vcpkg_dir)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+    } else {
+        println!("{} Installing vcpkg to D:\\libs\\vcpkg...", "→".blue());
+
+        run_powershell("if (!(Test-Path D:\\libs)) { New-Item -ItemType Directory -Path D:\\libs }")?;
+
+        let clone = Command::new("git")
+            .args(["clone", "--depth=1", "https://github.com/microsoft/vcpkg.git", "D:\\libs\\vcpkg"])
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit())
+            .status();
+
+        if clone.map(|s| !s.success()).unwrap_or(true) {
+            anyhow::bail!("Failed to clone vcpkg repository");
+        }
+
+        println!("{} Bootstrapping vcpkg...", "→".blue());
+        let bootstrap = Command::new("cmd")
+            .args(["/C", "bootstrap-vcpkg.bat", "-disableMetrics"])
+            .current_dir(vcpkg_dir)
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit())
+            .status();
+
+        if bootstrap.map(|s| !s.success()).unwrap_or(true) {
+            anyhow::bail!("Failed to bootstrap vcpkg");
+        }
+
+        println!("{} vcpkg installed to D:\\libs\\vcpkg", "✓".green());
+    }
+
+    // Step 2: Install FFmpeg via vcpkg (MSVC x64-windows build)
+    if ffmpeg_lib.exists() {
+        println!("{} FFmpeg (MSVC) already installed via vcpkg", "✓".green());
+    } else {
+        println!(
+            "{} Installing FFmpeg via vcpkg (this may take 10-30 minutes)...",
+            "→".blue()
+        );
+        let install = Command::new(vcpkg_exe.to_str().unwrap())
+            .args([
+                "install",
+                "ffmpeg[core,avcodec,avformat,avfilter,swresample,swscale,gpl]:x64-windows",
+                "--recurse",
+            ])
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit())
+            .status();
+
+        if install.map(|s| !s.success()).unwrap_or(true) {
+            anyhow::bail!("Failed to install FFmpeg via vcpkg");
+        }
+
+        println!("{} FFmpeg installed", "✓".green());
+    }
+
+    // Step 3: Set environment variables
+    println!("{} Setting FFmpeg environment variables...", "→".blue());
+    run_powershell(
+        "[Environment]::SetEnvironmentVariable('FFMPEG_DIR', 'D:\\libs\\vcpkg\\installed\\x64-windows', 'User')",
+    )?;
+    run_powershell(
+        "[Environment]::SetEnvironmentVariable('VCPKG_ROOT', 'D:\\libs\\vcpkg', 'User')",
+    )?;
+    run_powershell(
+        "$path = [Environment]::GetEnvironmentVariable('Path', 'User'); if ($path -notlike '*D:\\libs\\vcpkg\\installed\\x64-windows\\bin*') { [Environment]::SetEnvironmentVariable('Path', $path + ';D:\\libs\\vcpkg\\installed\\x64-windows\\bin', 'User') }",
+    )?;
+    println!("{} Environment variables set", "✓".green());
+    println!("   {} FFMPEG_DIR=D:\\libs\\vcpkg\\installed\\x64-windows", "→".blue());
+
+    Ok(())
+}
+
+#[cfg(not(target_os = "windows"))]
+fn setup_ffmpeg_windows() -> Result<()> {
+    Ok(())
+}
+
+#[cfg(target_os = "windows")]
+fn setup_build_tools() -> Result<()> {
+    use std::path::Path;
+
+    let cmake_installed = Command::new("cmake")
+        .arg("--version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+
+    if !cmake_installed {
+        println!("{} CMake not found, installing...", "→".blue());
+
+        run_powershell("if (!(Test-Path C:\\tmp)) { New-Item -ItemType Directory -Path C:\\tmp }")?;
+
+        println!("{} Downloading CMake installer...", "→".blue());
+        run_powershell(
+            "Invoke-WebRequest -Uri 'https://github.com/Kitware/CMake/releases/download/v3.28.3/cmake-3.28.3-windows-x86_64.msi' -OutFile 'C:\\tmp\\cmake.msi'",
+        )?;
+
+        println!("{} Installing CMake...", "→".blue());
+        run_powershell(
+            "Start-Process msiexec.exe -ArgumentList '/i', 'C:\\tmp\\cmake.msi', '/quiet', '/norestart', 'ADD_CMAKE_TO_PATH=System' -Wait",
+        )?;
+
+        println!("{} Cleaning up temporary files...", "→".blue());
+        run_powershell(
+            "Remove-Item -Path C:\\tmp\\cmake.msi -Force -ErrorAction SilentlyContinue",
+        )?;
+
+        run_powershell(
+            "$env:Path = [System.Environment]::GetEnvironmentVariable('Path','Machine') + ';' + [System.Environment]::GetEnvironmentVariable('Path','User')",
+        )?;
+
+        let cmake_now_installed = Path::new("C:\\Program Files\\CMake\\bin\\cmake.exe").exists();
+
+        if !cmake_now_installed {
+            println!("{} CMake installation failed", "✗".red().bold());
+            println!("{} Please install CMake manually:", "→".blue());
+            println!("   {}", "https://cmake.org/download/".cyan());
+            anyhow::bail!("Failed to install CMake");
+        }
+
+        println!("{} CMake installed", "✓".green());
+    } else {
+        println!("{} CMake already installed", "✓".green());
+    }
+
+    let pkgconfig_installed = Command::new("pkg-config")
+        .arg("--version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+
+    if !pkgconfig_installed {
+        println!(
+            "{} pkg-config not found, attempting to install...",
+            "→".blue()
+        );
+        let mut cmd = Command::new("choco");
+        cmd.arg("install").arg("pkgconfiglite").arg("-y");
+        let _ = cmd.stdout(Stdio::null()).stderr(Stdio::null()).status();
+
+        let pkgconfig_now_installed = Command::new("pkg-config")
+            .arg("--version")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+
+        if pkgconfig_now_installed {
+            println!("{} pkg-config installed", "✓".green());
+        } else {
+            println!(
+                "{} pkg-config not available (optional on Windows)",
+                "⚠".yellow()
+            );
+        }
+    } else {
+        println!("{} pkg-config already installed", "✓".green());
+    }
+
+    Ok(())
+}
+
+#[cfg(not(target_os = "windows"))]
+fn setup_build_tools() -> Result<()> {
+    Ok(())
+}
+
+#[cfg(target_os = "windows")]
+fn verify_windows_setup() -> Result<()> {
+    use std::path::Path;
+
+    println!("{}", "=== Verification ===".bold());
+    println!();
+
+    // FFmpeg (via vcpkg)
+    let ffmpeg_lib = Path::new("D:\\libs\\vcpkg\\installed\\x64-windows\\lib\\avcodec.lib");
+    if ffmpeg_lib.exists() {
+        println!("{} FFmpeg OK (D:\\libs\\vcpkg\\installed\\x64-windows)", "✓".green());
+    } else {
+        println!("{} FFmpeg not found - run `cargo x setup` to install", "✗".red());
+    }
+
+    // OpenCV
+    let opencv_dll = Path::new("D:\\libs\\opencv\\build\\x64\\vc16\\bin\\opencv_world490.dll");
+    if opencv_dll.exists() {
+        println!("{} OpenCV OK", "✓".green());
+    } else {
+        println!("{} OpenCV not found", "✗".red());
+    }
+
+    // LLVM
+    let llvm_exe = Path::new("C:\\Program Files\\LLVM\\bin\\clang.exe");
+    if llvm_exe.exists() {
+        println!("{} LLVM OK", "✓".green());
+    } else {
+        println!("{} LLVM not found", "✗".red());
+    }
+
+    println!();
+    println!("{}", "=== Environment Variables ===".bold());
+
+    if std::env::var("FFMPEG_DIR").is_ok() {
+        println!("{} FFMPEG_DIR set", "✓".green());
+    } else {
+        println!(
+            "{} FFMPEG_DIR not set (restart terminal after setup)",
+            "⚠".yellow()
+        );
+    }
+
+    if std::env::var("OPENCV_DIR").is_ok() {
+        println!("{} OPENCV_DIR set", "✓".green());
+    } else {
+        println!(
+            "{} OPENCV_DIR not set (restart terminal after setup)",
+            "⚠".yellow()
+        );
+    }
+
+    Ok(())
+}
+
+#[cfg(not(target_os = "windows"))]
+fn verify_windows_setup() -> Result<()> {
+    Ok(())
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn setup_linux(skip_verify: bool) -> Result<()> {
+    println!("{}", "Checking prerequisites...".bold());
+    check_command("git", "Git not found")?;
+    check_command("cargo", "Rust not found. Install from: https://rustup.rs/")?;
+    println!("{} Prerequisites OK", "✓".green());
+    println!();
+
+    #[cfg(target_os = "linux")]
+    {
+        println!("{}", "Installing dependencies via apt...".bold());
+        println!("{} Updating package list...", "→".blue());
+        let mut cmd = Command::new("sudo");
+        cmd.args(["apt-get", "update", "-y"]);
+        execute_command(&mut cmd)?;
+
+        println!("{} Installing build tools...", "→".blue());
+        let mut cmd = Command::new("sudo");
+        cmd.args([
+            "apt-get", "install", "-y",
+            "cmake", "pkg-config", "clang", "libclang-dev",
+        ]);
+        execute_command(&mut cmd)?;
+
+        println!("{} Installing FFmpeg dev libraries...", "→".blue());
+        let mut cmd = Command::new("sudo");
+        cmd.args([
+            "apt-get", "install", "-y",
+            "libavcodec-dev", "libavformat-dev", "libavutil-dev",
+            "libavdevice-dev", "libavfilter-dev",
+            "libswscale-dev", "libswresample-dev",
+        ]);
+        execute_command(&mut cmd)?;
+
+        println!("{} Installing OpenCV...", "→".blue());
+        let mut cmd = Command::new("sudo");
+        cmd.args([
+            "apt-get", "install", "-y",
+            "libopencv-dev",
+        ]);
+        execute_command(&mut cmd)?;
+
+        println!("{} Installing audio libraries...", "→".blue());
+        let mut cmd = Command::new("sudo");
+        cmd.args(["apt-get", "install", "-y", "libasound2-dev"]);
+        execute_command(&mut cmd)?;
+    }
+
+    println!();
+
+    if !skip_verify {
+        println!("{}", "Verifying installation...".bold());
+        verify_linux_setup()?;
+    }
+
+    println!();
+    println!("{}", "✅ Setup complete!".green().bold());
+    println!("{} You can now run: {}", "→".blue(), "cargo build".cyan());
+
+    Ok(())
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+fn setup_linux(_skip_verify: bool) -> Result<()> {
+    anyhow::bail!("Linux/macOS setup can only be run on Linux/macOS")
+}
+
+#[cfg(target_os = "macos")]
+fn setup_macos(skip_verify: bool) -> Result<()> {
+    println!("{}", "Checking prerequisites...".bold());
+    check_command("git", "Git not found")?;
+    check_command("cargo", "Rust not found. Install from: https://rustup.rs/")?;
+    check_command("brew", "Homebrew not found. Install from: https://brew.sh/")?;
+    println!("{} Prerequisites OK", "✓".green());
+    println!();
+
+    println!("{}", "Installing dependencies via Homebrew...".bold());
+
+    println!("{} Installing build tools...", "→".blue());
+    let mut cmd = Command::new("brew");
+    cmd.args(["install", "cmake", "pkg-config", "llvm"]);
+    execute_command(&mut cmd)?;
+
+    // brew's LLVM is not in PATH by default; set LIBCLANG_PATH so opencv-rs bindgen works
+    println!("{} Configuring LLVM (brew)...", "→".blue());
+    let llvm_prefix_output = Command::new("brew")
+        .args(["--prefix", "llvm"])
+        .output();
+    if let Ok(out) = llvm_prefix_output {
+        if out.status.success() {
+            let prefix = String::from_utf8_lossy(&out.stdout).trim().to_string();
+            let libclang_path = format!("{}/lib", prefix);
+            println!(
+                "{} LIBCLANG_PATH={} (add to your shell profile)",
+                "→".blue(),
+                libclang_path.cyan()
+            );
+            println!(
+                "   {}",
+                format!("export LIBCLANG_PATH={}", libclang_path).cyan()
+            );
+            // Set for current process so cargo build works immediately after setup
+            std::env::set_var("LIBCLANG_PATH", &libclang_path);
+        }
+    }
+
+    println!("{} Installing OpenCV...", "→".blue());
+    let mut cmd = Command::new("brew");
+    cmd.args(["install", "opencv"]);
+    execute_command(&mut cmd)?;
+
+    println!("{} Installing FFmpeg...", "→".blue());
+    let mut cmd = Command::new("brew");
+    cmd.args(["install", "ffmpeg"]);
+    execute_command(&mut cmd)?;
+
+    println!();
+
+    if !skip_verify {
+        println!("{}", "Verifying installation...".bold());
+        verify_macos_setup()?;
+    }
+
+    println!();
+    println!("{}", "✅ Setup complete!".green().bold());
+    println!("{} You can now run: {}", "→".blue(), "cargo build".cyan());
+
+    Ok(())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn setup_macos(_skip_verify: bool) -> Result<()> {
+    anyhow::bail!("macOS setup can only be run on macOS")
+}
+
+fn check_command(cmd: &str, error_msg: &str) -> Result<()> {
+    let result = Command::new(cmd)
+        .arg("--version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+
+    match result {
+        Ok(status) if status.success() => {
+            println!("{} {} found", "✓".green(), cmd);
+            Ok(())
+        }
+        _ => {
+            println!("{} {}", "✗".red().bold(), error_msg);
+            anyhow::bail!(error_msg.to_string())
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn run_powershell(script: &str) -> Result<()> {
+    let mut cmd = Command::new("powershell");
+    cmd.arg("-NoLogo")
+        .arg("-NoProfile")
+        .arg("-NonInteractive")
+        .arg("-Command")
+        .arg(script);
+
+    let status = cmd
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .status()?;
+
+    if !status.success() {
+        anyhow::bail!("PowerShell command failed");
+    }
+
+    Ok(())
+}
+
+#[cfg(not(target_os = "windows"))]
+fn run_powershell(_script: &str) -> Result<()> {
+    anyhow::bail!("PowerShell is only available on Windows")
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn verify_linux_setup() -> Result<()> {
+    check_pkg_config("libavcodec", "FFmpeg")?;
+    check_pkg_config("opencv4", "OpenCV")?;
+
+    #[cfg(target_os = "linux")]
+    check_pkg_config("alsa", "ALSA")?;
+
+    Ok(())
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+#[allow(dead_code)]
+fn verify_linux_setup() -> Result<()> {
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn verify_macos_setup() -> Result<()> {
+    verify_linux_setup()
+}
+
+#[cfg(not(target_os = "macos"))]
+#[allow(dead_code)]
+fn verify_macos_setup() -> Result<()> {
+    Ok(())
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn check_pkg_config(package: &str, name: &str) -> Result<()> {
+    let result = Command::new("pkg-config")
+        .arg("--exists")
+        .arg(package)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+
+    match result {
+        Ok(status) if status.success() => {
+            println!("{} {} OK", "✓".green(), name);
+            Ok(())
+        }
+        _ => {
+            println!("{} {} not found", "✗".red(), name);
+            Ok(()) // warn only
+        }
+    }
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+#[allow(dead_code)]
+fn check_pkg_config(_package: &str, _name: &str) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(target_os = "windows")]
+fn is_admin() -> Result<bool> {
+    let output = Command::new("powershell")
+        .arg("-NoProfile")
+        .arg("-NonInteractive")
+        .arg("-Command")
+        .arg("([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)")
+        .output()?;
+
+    let is_admin = String::from_utf8_lossy(&output.stdout)
+        .trim()
+        .eq_ignore_ascii_case("true");
+
+    Ok(is_admin)
+}
+
+#[cfg(not(target_os = "windows"))]
+fn is_admin() -> Result<bool> {
+    Ok(false)
+}


### PR DESCRIPTION
## Summary

xtask（`cargo x setup`）とシェルスクリプト（`scripts/install_deps.sh`）を追加し、Windows・Linux・macOS でのビルド環境構築を自動化する。あわせて `.cargo/config.toml` と `media-core/build.rs` の設定を整理した。

## Changes

- **xtask 追加** (`xtask/`): `cargo x setup` でプラットフォームごとに依存ライブラリを自動インストール
  - Windows: vcpkg 経由で FFmpeg (MSVC x64-windows)、公式リリースから OpenCV 4.9.0、Chocolatey 経由で LLVM をインストール
  - Linux (Debian/Ubuntu): apt-get で FFmpeg 開発ライブラリ・OpenCV・ALSA を一括インストール
  - macOS: Homebrew で FFmpeg・OpenCV・LLVM をインストール、`brew --prefix llvm` から `LIBCLANG_PATH` を自動設定
- **`scripts/install_deps.sh` 追加**: Ubuntu/Debian・Fedora・Arch・macOS 対応のシェルスクリプト
  - Fedora: `clang-devel` を追加（opencv-rs の bindgen に必要）
  - macOS: `LIBCLANG_PATH` をエクスポートし、シェルプロファイルへの追記手順を表示
- **`.cargo/config.toml` 整備**: Windows MSVC 向けリンカ設定と環境変数を追加
  - `FFMPEG_DIR`・`OPENCV_DIR`・`LIBCLANG_PATH` 等を `force = true` で設定し、ビルドスクリプトまで確実に伝達
- **`media-core/build.rs` 整理**: pkg-config 依存を除去し、環境変数ベースの検出に統一
- **ルート `build.rs` 削除**: ワークスペースルートに `[package]` がないため実行されない不要ファイル
- **`Cargo.toml`**: ワークスペースメンバーに `xtask` を追加

## Related Issues

なし

## Test Plan

- [x] `cargo test --all --all-features` passes
- [x] `cargo clippy --all --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes