### PR TITLE
refactor(ascii-term): remove dead player/audio/renderer items

### DIFF
--- a/app/ascii-term/src/audio.rs
+++ b/app/ascii-term/src/audio.rs
@@ -118,18 +118,16 @@ impl Iterator for DirectAudioSource {
     }
 }
 
-#[allow(dead_code)]
 pub struct AudioPlayer {
     _stream: OutputStream,
     sink: Sink,
     is_muted: Arc<AtomicBool>,
     original_volume: f32,
-    audio_sender: Option<Sender<Vec<f32>>>,
+    _audio_sender: Option<Sender<Vec<f32>>>,
     decoder_thread: Option<thread::JoinHandle<()>>,
     stop_signal: Arc<AtomicBool>,
-    is_finished: Arc<AtomicBool>,
+    _is_finished: Arc<AtomicBool>,
     sample_rate: u32,
-    channels: u16,
 }
 
 impl AudioPlayer {
@@ -191,12 +189,11 @@ impl AudioPlayer {
             sink,
             is_muted: Arc::new(AtomicBool::new(false)),
             original_volume: 1.0,
-            audio_sender: Some(audio_sender),
+            _audio_sender: Some(audio_sender),
             decoder_thread: Some(decoder_thread),
             stop_signal,
-            is_finished,
+            _is_finished: is_finished,
             sample_rate,
-            channels,
         })
     }
 
@@ -230,27 +227,6 @@ impl AudioPlayer {
         Ok(())
     }
 
-    pub fn set_volume(&mut self, volume: f32) -> Result<()> {
-        let clamped_volume = volume.clamp(0.0, 1.0);
-        self.original_volume = clamped_volume;
-
-        if !self.is_muted.load(Ordering::Relaxed) {
-            self.sink.set_volume(clamped_volume);
-        }
-
-        println!("Volume set to: {:.2}", clamped_volume);
-        Ok(())
-    }
-
-    #[allow(dead_code)]
-    pub fn volume(&self) -> f32 {
-        if self.is_muted.load(Ordering::Relaxed) {
-            0.0
-        } else {
-            self.original_volume
-        }
-    }
-
     pub fn mute(&mut self) -> Result<()> {
         println!("Muting audio");
         self.is_muted.store(true, Ordering::Relaxed);
@@ -279,16 +255,6 @@ impl AudioPlayer {
 
     pub fn is_muted(&self) -> bool {
         self.is_muted.load(Ordering::Relaxed)
-    }
-
-    #[allow(dead_code)]
-    pub fn sample_rate(&self) -> u32 {
-        self.sample_rate
-    }
-
-    #[allow(dead_code)]
-    pub fn channels(&self) -> u16 {
-        self.channels
     }
 }
 

--- a/app/ascii-term/src/char_maps.rs
+++ b/app/ascii-term/src/char_maps.rs
@@ -74,12 +74,6 @@ pub fn get_char_map_name(index: u8) -> &'static str {
     CHAR_MAP_NAMES[index]
 }
 
-/// Get the total number of character maps
-#[allow(dead_code)]
-pub fn char_map_count() -> usize {
-    CHAR_MAPS.len()
-}
-
 /// Mapping lightness values (0-255) to characters
 pub fn luminance_to_char(luminance: u8, char_map: &str) -> char {
     let chars: Vec<char> = char_map.chars().collect();

--- a/app/ascii-term/src/main.rs
+++ b/app/ascii-term/src/main.rs
@@ -41,10 +41,6 @@ struct Args {
     #[arg(short, long, default_value = "1")]
     width_mod: u32,
 
-    /// Allow frame skipping when behind
-    #[arg(long)]
-    allow_frame_skip: bool,
-
     /// Add newlines to output
     #[arg(short, long)]
     newlines: bool,
@@ -122,7 +118,6 @@ async fn main() -> Result<()> {
         char_map_index: args.char_map,
         grayscale: args.gray,
         width_modifier: args.width_mod,
-        allow_frame_skip: args.allow_frame_skip,
         add_newlines: args.newlines,
         enable_audio: !args.no_audio && media_file.info.has_audio,
     };

--- a/app/ascii-term/src/player.rs
+++ b/app/ascii-term/src/player.rs
@@ -19,8 +19,6 @@ pub struct PlayerConfig {
     pub char_map_index: u8,
     pub grayscale: bool,
     pub width_modifier: u32,
-    #[allow(dead_code)]
-    pub allow_frame_skip: bool,
     pub add_newlines: bool,
     pub enable_audio: bool,
 }
@@ -33,7 +31,6 @@ impl Default for PlayerConfig {
             char_map_index: 0,
             grayscale: false,
             width_modifier: 1,
-            allow_frame_skip: false,
             add_newlines: false,
             enable_audio: true,
         }
@@ -41,28 +38,14 @@ impl Default for PlayerConfig {
 }
 
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 pub enum PlayerCommand {
     Play,
     Pause,
     Stop,
-    Seek(Duration),
-    SetVolume(f32),
-    Mute,
-    Unmute,
     TogglePlayPause,
     ToggleMute,
     SetCharMap(u8),
     ToggleGrayscale,
-    Resize(u16, u16),
-}
-
-#[derive(Debug, Clone, PartialEq)]
-#[allow(dead_code)]
-pub enum PlayerState {
-    Playing,
-    Paused,
-    Stopped,
 }
 
 pub struct Player {
@@ -96,7 +79,6 @@ impl Player {
             char_map_index: config.char_map_index,
             grayscale: config.grayscale,
             add_newlines: config.add_newlines,
-            width_modifier: config.width_modifier,
         };
 
         let renderer = AsciiRenderer::new(render_config);
@@ -450,17 +432,6 @@ impl Player {
                     println!("Audio not available for mute toggle");
                 }
             }
-            PlayerCommand::SetVolume(volume) => {
-                if let Some(audio_player) = &mut self.audio_player {
-                    if let Err(e) = audio_player.set_volume(volume) {
-                        eprintln!("Warning: Failed to set volume: {}", e);
-                    } else {
-                        println!("Volume set to: {:.2}", volume);
-                    }
-                } else {
-                    println!("Audio not available for volume control");
-                }
-            }
             PlayerCommand::SetCharMap(index) => {
                 self.renderer.set_char_map(index);
                 println!(
@@ -473,19 +444,7 @@ impl Player {
                 self.renderer.set_grayscale(self.config.grayscale);
                 println!("Grayscale mode: {}", self.config.grayscale);
             }
-            PlayerCommand::Resize(width, height) => {
-                self.renderer.update_resolution(width, height);
-                println!("Resolution updated: {}x{}", width, height);
-            }
-            _ => {
-                println!("Command not implemented: {:?}", command);
-            }
         }
         Ok(())
-    }
-
-    #[allow(dead_code)]
-    pub fn command_sender(&self) -> Sender<PlayerCommand> {
-        self.command_tx.clone()
     }
 }

--- a/app/ascii-term/src/renderer.rs
+++ b/app/ascii-term/src/renderer.rs
@@ -12,7 +12,6 @@ pub struct RenderConfig {
     pub char_map_index: u8,
     pub grayscale: bool,
     pub add_newlines: bool,
-    pub width_modifier: u32,
 }
 
 impl Default for RenderConfig {
@@ -23,7 +22,6 @@ impl Default for RenderConfig {
             char_map_index: 0,
             grayscale: false,
             add_newlines: false,
-            width_modifier: 1,
         }
     }
 }
@@ -47,16 +45,6 @@ impl AsciiRenderer {
             config,
             resizer: fr::Resizer::new(),
         }
-    }
-
-    #[allow(dead_code)]
-    pub fn update_config(&mut self, config: RenderConfig) {
-        self.config = config;
-    }
-
-    pub fn update_resolution(&mut self, width: u16, height: u16) {
-        self.config.target_width = (width / self.config.width_modifier as u16) as u32;
-        self.config.target_height = height as u32;
     }
 
     pub fn set_char_map(&mut self, index: u8) {


### PR DESCRIPTION
Closes #13.

## Removed (unambiguously dead)
- `player.rs`: `PlayerState` enum, `Player::command_sender()`.
- `char_maps.rs`: `char_map_count()`.
- `renderer.rs`: `AsciiRenderer::update_config()`.
- `audio.rs`: `AudioPlayer::{volume, sample_rate, channels}` getters; dropped the struct-level `#[allow(dead_code)]`. Write-only lifetime-guard fields (`audio_sender`, `is_finished`) are now `_`-prefixed (same convention as `_stream`); the `channels` field (read only by the removed getter) is dropped. `sample_rate` is kept (read in `play()`).

## Removed per review decision (unwired controls → remove)
- `PlayerCommand::{Seek, SetVolume, Mute, Unmute, Resize}` and their `handle_command` arms; the `_ => {}` catch-all is gone so the match is now exhaustive. Mute still works via `ToggleMute` (`m` key).
- `AudioPlayer::set_volume()` (only reachable from the removed `SetVolume`).
- Cascade: removing `Resize` made `AsciiRenderer::update_resolution()` dead, which in turn made `RenderConfig.width_modifier` dead — both removed. (`PlayerConfig.width_modifier`, a separate field, is still used.)

## Removed per review decision (no-op CLI flag → remove)
- `--allow-frame-skip` CLI arg and `PlayerConfig.allow_frame_skip`. The flag was never read; frame-skip in `play_video` is unconditional, so removing it changes no runtime behaviour.

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace` (8 tests pass)