### PR TITLE
fix(codec): return Result instead of panicking in resize and async decoder

### DIFF
--- a/app/codec/src/image/processor.rs
+++ b/app/codec/src/image/processor.rs
@@ -38,10 +38,10 @@ impl From<ResizeAlgorithm> for fr::ResizeAlg {
     fn from(alg: ResizeAlgorithm) -> Self {
         match alg {
             ResizeAlgorithm::Nearest => fr::ResizeAlg::Nearest,
-            ResizeAlgorithm::Bilinear => unimplemented!(),
-            ResizeAlgorithm::Bicubic => unimplemented!(),
-            ResizeAlgorithm::Lanczos3 => unimplemented!(),
-            ResizeAlgorithm::CatmullRom => unimplemented!(),
+            ResizeAlgorithm::Bilinear => fr::ResizeAlg::Convolution(fr::FilterType::Bilinear),
+            ResizeAlgorithm::Bicubic => fr::ResizeAlg::Convolution(fr::FilterType::Mitchell),
+            ResizeAlgorithm::Lanczos3 => fr::ResizeAlg::Convolution(fr::FilterType::Lanczos3),
+            ResizeAlgorithm::CatmullRom => fr::ResizeAlg::Convolution(fr::FilterType::CatmullRom),
         }
     }
 }
@@ -430,4 +430,24 @@ fn hsv_to_rgb(h: f32, s: f32, v: f32) -> (u8, u8, u8) {
     let b = ((b_prime + m) * 255.0) as u8;
 
     (r, g, b)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// すべての ResizeAlgorithm が panic せず fr::ResizeAlg に変換できること
+    /// （以前は Lanczos3 など既定値が unimplemented!() でパニックしていた回帰の防止）
+    #[test]
+    fn resize_algorithm_into_fr_is_total() {
+        for alg in [
+            ResizeAlgorithm::Nearest,
+            ResizeAlgorithm::Bilinear,
+            ResizeAlgorithm::Bicubic,
+            ResizeAlgorithm::Lanczos3,
+            ResizeAlgorithm::CatmullRom,
+        ] {
+            let _: fr::ResizeAlg = alg.into();
+        }
+    }
 }

--- a/app/codec/src/video/decoder.rs
+++ b/app/codec/src/video/decoder.rs
@@ -85,15 +85,15 @@ impl AsyncVideoDecoder {
     pub async fn decode_one(&mut self) -> Result<Option<VideoFrame>> {
         let inner = Arc::clone(&self.inner);
 
-        let avio_frame = tokio::task::spawn_blocking(move || {
-            inner
-                .lock()
-                .expect("VideoDecoder mutex not poisoned")
-                .decode_one()
-        })
-        .await
-        .map_err(|e| MediaError::Pipeline(format!("spawn_blocking panicked: {e}")))?
-        .map_err(MediaError::Decode)?;
+        let avio_frame =
+            tokio::task::spawn_blocking(move || -> Result<Option<avio::VideoFrame>> {
+                let mut guard = inner
+                    .lock()
+                    .map_err(|_| MediaError::Pipeline("VideoDecoder mutex poisoned".to_string()))?;
+                guard.decode_one().map_err(MediaError::Decode)
+            })
+            .await
+            .map_err(|e| MediaError::Pipeline(format!("spawn_blocking panicked: {e}")))??;
 
         match avio_frame {
             Some(frame) => {


### PR DESCRIPTION
Closes #10.

## Problem
Two spots in `codec` panicked in library code instead of returning an error.

1. `image/processor.rs` — `From<ResizeAlgorithm> for fr::ResizeAlg` returned `unimplemented!()` for `Bilinear`/`Bicubic`/`Lanczos3`/`CatmullRom`. Since `ImageProcessorConfig::default()` uses `Lanczos3` and `ImageProcessor::resize` feeds it through `alg.into()`, a default-configured resize would panic.
2. `video/decoder.rs:91` — `.expect("VideoDecoder mutex not poisoned")` in the async `decode_one` blocking path turned a poisoned lock into an opaque panic.

## Fix
1. Map every `ResizeAlgorithm` to a real `fr::ResizeAlg::Convolution(..)` (Bilinear→Bilinear, Bicubic→Mitchell, Lanczos3→Lanczos3, CatmullRom→CatmullRom). The `From` impl is now total — no `unimplemented!()`.
2. Replace the mutex `.expect(...)` with `map_err` to `MediaError::Pipeline`, so a poisoned lock returns `Err` like the existing `spawn_blocking` panic handling.

## Test
Added `resize_algorithm_into_fr_is_total` exercising every variant through `.into()` (regression guard for the panic).

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace` (9 tests pass, incl. the new one)