### PR TITLE
refactor: deduplicate external-command invocation in xtask and downloader

### DIFF
--- a/app/downloader/src/youtube.rs
+++ b/app/downloader/src/youtube.rs
@@ -11,26 +11,15 @@ pub async fn download_video(url: &str, _browser: &str) -> Result<PathBuf> {
 
     let temp_file = NamedTempFile::new().map_err(DownloaderError::Io)?;
     let temp_path = temp_file.path().to_path_buf();
+    let temp_path_str = temp_path
+        .to_str()
+        .ok_or_else(|| DownloaderError::Process("Temporary path is not valid UTF-8".to_string()))?;
 
-    let output = Command::new("yt-dlp")
-        .arg(url)
-        // .arg("--cookies-from-browser")
-        // .arg(browser)
-        .arg("-f")
-        .arg("best[ext=mp4]/best")
-        .arg("-o")
-        .arg(&temp_path)
-        .output()
-        .await
-        .map_err(|e| DownloaderError::Process(format!("Failed to execute yt-dlp: {}", e)))?;
-
-    if !output.status.success() {
-        let error_msg = String::from_utf8_lossy(&output.stderr);
-        return Err(DownloaderError::Download(format!(
-            "yt-dlp failed: {}",
-            error_msg
-        )));
-    }
+    run_ytdlp(
+        &[url, "-f", "best[ext=mp4]/best", "-o", temp_path_str],
+        "yt-dlp failed",
+    )
+    .await?;
 
     let persistent_path = temp_file.into_temp_path();
     Ok(persistent_path.to_path_buf())
@@ -40,54 +29,24 @@ pub async fn download_video(url: &str, _browser: &str) -> Result<PathBuf> {
 pub async fn get_video_info(url: &str) -> Result<VideoInfo> {
     check_ytdlp_installed().await?;
 
-    let output = Command::new("yt-dlp")
-        .arg(url)
-        .arg("--dump-json")
-        .arg("--no-download")
-        .output()
-        .await
-        .map_err(|e| DownloaderError::Process(format!("Failed to execute yt-dlp: {}", e)))?;
-
-    if !output.status.success() {
-        let error_msg = String::from_utf8_lossy(&output.stderr);
-        return Err(DownloaderError::Download(format!(
-            "Failed to get video info: {}",
-            error_msg
-        )));
-    }
-
-    let json_str = String::from_utf8_lossy(&output.stdout);
-    let info: VideoInfo = serde_json::from_str(&json_str)
-        .map_err(|e| DownloaderError::Parse(format!("Failed to parse video info: {}", e)))?;
-
-    Ok(info)
+    let stdout = run_ytdlp(
+        &[url, "--dump-json", "--no-download"],
+        "Failed to get video info",
+    )
+    .await?;
+    parse_json(&stdout, "video info")
 }
 
 /// Get available formats
 pub async fn list_formats(url: &str) -> Result<Vec<FormatInfo>> {
     check_ytdlp_installed().await?;
 
-    let output = Command::new("yt-dlp")
-        .arg(url)
-        .arg("--list-formats")
-        .arg("--dump-json")
-        .output()
-        .await
-        .map_err(|e| DownloaderError::Process(format!("Failed to execute yt-dlp: {}", e)))?;
-
-    if !output.status.success() {
-        let error_msg = String::from_utf8_lossy(&output.stderr);
-        return Err(DownloaderError::Download(format!(
-            "Failed to list formats: {}",
-            error_msg
-        )));
-    }
-
-    let json_str = String::from_utf8_lossy(&output.stdout);
-    let formats: Vec<FormatInfo> = serde_json::from_str(&json_str)
-        .map_err(|e| DownloaderError::Parse(format!("Failed to parse formats: {}", e)))?;
-
-    Ok(formats)
+    let stdout = run_ytdlp(
+        &[url, "--list-formats", "--dump-json"],
+        "Failed to list formats",
+    )
+    .await?;
+    parse_json(&stdout, "formats")
 }
 
 /// Check if yt-dlp is installed
@@ -101,6 +60,32 @@ async fn check_ytdlp_installed() -> Result<()> {
                 .to_string(),
         )),
     }
+}
+
+/// Run yt-dlp with the given arguments, returning captured stdout on success.
+async fn run_ytdlp(args: &[&str], failure_context: &str) -> Result<Vec<u8>> {
+    let output = Command::new("yt-dlp")
+        .args(args)
+        .output()
+        .await
+        .map_err(|e| DownloaderError::Process(format!("Failed to execute yt-dlp: {}", e)))?;
+
+    if !output.status.success() {
+        let error_msg = String::from_utf8_lossy(&output.stderr);
+        return Err(DownloaderError::Download(format!(
+            "{}: {}",
+            failure_context, error_msg
+        )));
+    }
+
+    Ok(output.stdout)
+}
+
+/// Parse yt-dlp JSON output into the requested type.
+fn parse_json<T: serde::de::DeserializeOwned>(stdout: &[u8], what: &str) -> Result<T> {
+    let json_str = String::from_utf8_lossy(stdout);
+    serde_json::from_str(&json_str)
+        .map_err(|e| DownloaderError::Parse(format!("Failed to parse {}: {}", what, e)))
 }
 
 /// Video information structure

--- a/xtask/src/setup.rs
+++ b/xtask/src/setup.rs
@@ -47,13 +47,7 @@ fn setup_windows(skip_verify: bool) -> Result<()> {
     check_command("git", "Git not found. Install from: https://git-scm.com/")?;
     check_command("cargo", "Rust not found. Install from: https://rustup.rs/")?;
 
-    let has_choco = Command::new("choco")
-        .arg("--version")
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false);
+    let has_choco = command_succeeds("choco", "--version");
 
     if has_choco {
         println!("{} Chocolatey found", "✓".green());
@@ -105,13 +99,7 @@ fn setup_windows(skip_verify: bool) -> Result<()> {
 
     // LLVM: required for avio (ff-sys) bindgen
     println!("{}", "Setting up LLVM (clang)...".bold());
-    let llvm_installed = Command::new("clang")
-        .arg("--version")
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false);
+    let llvm_installed = command_succeeds("clang", "--version");
 
     if !llvm_installed {
         let llvm_path = Path::new("C:\\Program Files\\LLVM\\bin\\clang.exe");
@@ -287,13 +275,7 @@ fn setup_ffmpeg_windows() -> Result<()> {
 fn setup_build_tools() -> Result<()> {
     use std::path::Path;
 
-    let cmake_installed = Command::new("cmake")
-        .arg("--version")
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false);
+    let cmake_installed = command_succeeds("cmake", "--version");
 
     if !cmake_installed {
         println!("{} CMake not found, installing...", "→".blue());
@@ -333,13 +315,7 @@ fn setup_build_tools() -> Result<()> {
         println!("{} CMake already installed", "✓".green());
     }
 
-    let pkgconfig_installed = Command::new("pkg-config")
-        .arg("--version")
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false);
+    let pkgconfig_installed = command_succeeds("pkg-config", "--version");
 
     if !pkgconfig_installed {
         println!(
@@ -350,13 +326,7 @@ fn setup_build_tools() -> Result<()> {
         cmd.arg("install").arg("pkgconfiglite").arg("-y");
         let _ = cmd.stdout(Stdio::null()).stderr(Stdio::null()).status();
 
-        let pkgconfig_now_installed = Command::new("pkg-config")
-            .arg("--version")
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status()
-            .map(|s| s.success())
-            .unwrap_or(false);
+        let pkgconfig_now_installed = command_succeeds("pkg-config", "--version");
 
         if pkgconfig_now_installed {
             println!("{} pkg-config installed", "✓".green());
@@ -558,22 +528,24 @@ fn setup_macos(_skip_verify: bool) -> Result<()> {
     anyhow::bail!("macOS setup can only be run on macOS")
 }
 
-fn check_command(cmd: &str, error_msg: &str) -> Result<()> {
-    let result = Command::new(cmd)
-        .arg("--version")
+/// Returns true if `program arg` runs and exits successfully (probe for an installed tool).
+fn command_succeeds(program: &str, arg: &str) -> bool {
+    Command::new(program)
+        .arg(arg)
         .stdout(Stdio::null())
         .stderr(Stdio::null())
-        .status();
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
 
-    match result {
-        Ok(status) if status.success() => {
-            println!("{} {} found", "✓".green(), cmd);
-            Ok(())
-        }
-        _ => {
-            println!("{} {}", "✗".red().bold(), error_msg);
-            anyhow::bail!(error_msg.to_string())
-        }
+fn check_command(cmd: &str, error_msg: &str) -> Result<()> {
+    if command_succeeds(cmd, "--version") {
+        println!("{} {} found", "✓".green(), cmd);
+        Ok(())
+    } else {
+        println!("{} {}", "✗".red().bold(), error_msg);
+        anyhow::bail!(error_msg.to_string())
     }
 }
 


### PR DESCRIPTION
Closes #15.

## downloader (`youtube.rs`)
The yt-dlp spawn + status-check + JSON-parse boilerplate was repeated across `download_video`, `get_video_info`, and `list_formats`. Extracted two helpers:
- `async fn run_ytdlp(args: &[&str], failure_context: &str) -> Result<Vec<u8>>` — spawns yt-dlp, maps spawn failure to `Process`, checks exit status (mapping failure to `Download` with the given context + stderr), returns stdout.
- `fn parse_json<T: DeserializeOwned>(stdout: &[u8], what: &str) -> Result<T>` — the `serde_json` parse + `Parse` error mapping.

Each public fn is now a couple of lines. All error message text is preserved byte-for-byte. `check_ytdlp_installed` is left as-is (it maps failure to `DependencyMissing`, a different semantic).

## xtask (`setup.rs`)
The tool-probe expression
```rust
Command::new(X).arg("--version").stdout(Stdio::null()).stderr(Stdio::null())
    .status().map(|s| s.success()).unwrap_or(false)
```
was repeated 5× (choco, clang, cmake, pkg-config ×2). Extracted `fn command_succeeds(program: &str, arg: &str) -> bool` and routed `check_command` through it too, so the helper is exercised on every platform (no dead-code on non-Windows).

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`

All touched code compiles on the Windows host (the downloader changes are OS-independent; the `setup.rs` probe replacements live in `#[cfg(windows)]` functions plus the cross-platform `check_command`/`command_succeeds`).